### PR TITLE
Only record whitelisted content types

### DIFF
--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -26,7 +26,7 @@ define([
     version: timetravelVersion,
 
     // Only these content types will be recorded in the history. Used to
-    // prevent huge notebooks from saving plots.
+    // prevent file size growth from recording plots.
     allowedContentTypes: [
       'text/plain',
     ],


### PR DESCRIPTION
Summary
-----

Before, the extension would record all inputs / outputs, including for cells
that output graphs. This would make file sizes rapidly increase beyond what
what we thought was acceptable.

This commit only permits the extension to record output of content type
`text/plain` which corresponds to the textual Python output. This makes
deploying to students much more reasonable.

Example metadata from a cell that produces graphs:

```
{
  "history": [
    {
      "timestamp": "2016-11-28T09:01:13.345Z",
      "code": "t.scatter('x')",
      "response": {
        "version": "5.0",
        "msg_type": "display_data",
        "content": {
          "metadata": {},
          "data": {
            "text/plain": "<matplotlib.figure.Figure at 0x117732cf8>"
          }
        },
        "metadata": {}
      }
    },
    {
      "timestamp": "2016-11-28T09:05:26.483Z",
      "code": "t.scatter('y')",
      "response": {
        "version": "5.0",
        "msg_type": "display_data",
        "content": {
          "metadata": {},
          "data": {
            "text/plain": "<matplotlib.figure.Figure at 0x1178799b0>"
          }
        },
        "metadata": {}
      }
    }
  ],
  "trusted": true,
  "collapsed": false
}
```

How to test
-----

1. Run a cell that produces a plot multiple times. Verify that the plot does
   not appear in the metadata.